### PR TITLE
Return nil for failed lookups (empty hashes and empty arrays).

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ running `hiera applications` would run the query against the configured database
 
 The default_query key is special: it is in fact a default for anything in this hierarchy that is not specified with its own key. For example, running `hiera booksdb` would run default_query with the key variable in the query being interpolated as "booksdb".
 
+Empty arrays and empty hashes returned from the database will be collapsed to nil as Puppet modules expect. Empty (zero-length) non-nil string values returned by the query suggest an actual empty column in the database and are returned as empty strings.
 
 ### Using
 
@@ -58,8 +59,7 @@ Hiera configuration is pretty simple
 
 ## Known issues
 
-1. It always return an Array of hashes regardless of the number of items returned. (I did this on purpose because it is what I needed but I may be persuaded to do otherwise)
-2. This README is poorly written.
+1. This README is poorly written.
 
 
 ## Contributing

--- a/lib/hiera/backend/postgres_backend.rb
+++ b/lib/hiera/backend/postgres_backend.rb
@@ -61,7 +61,12 @@ class Hiera
           end
 
         end
-          return answer
+        unless answer.kind_of? String
+            if answer.empty?
+                answer = nil
+            end
+        end
+        return answer
       end
 
 


### PR DESCRIPTION
According to http://docs.puppetlabs.com/hiera/1/puppet.html#automatic-parameter-lookup all Puppet classes declared in a resource-like manner will search for defaults in Hiera unless those defaults are specifically overridden in the class declaration.

This means that unless there is a hierarchy for such a module with a suitable query that an empty array would have been returned. The PuppetLabs modules such as puppetlabs-puppetdb do not deal well with an empty array and expect nil to be returned in the case of no data found in the backend.

This patch checks for empty arrays and empty hashes, setting the return value to nil if it finds those. This lets modules which expect to find valid data if anything other than nil is returned to continue to work with their defaults. 
