### PR TITLE
When making a priority lookup, try each hierarchy entry until a valid response is found

### DIFF
--- a/lib/hiera/backend/postgres_backend.rb
+++ b/lib/hiera/backend/postgres_backend.rb
@@ -57,6 +57,10 @@ class Hiera
             answer = Backend.merge_answer(query(new_answer),answer)
           else
             answer = query(new_answer)
+            if answer.length == 0
+              answer = nil
+              next
+            end
             break
           end
 


### PR DESCRIPTION
Currently, when using a priority response type, the first Postgresql query is returned, even if it matches 0 rows. This proposed change will cause the backend to try all of the possible queries until it finds one that works, and returns nil when the list of queries is exhausted. If this is merged, please bump version and update rubygem too. Thank you!